### PR TITLE
Add GEO/AEO Tracker - AI visibility analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [BDP](https://me.bdp.cn/home.html) - Data analysis platform.
 - - [Crawlbase](https://crawlbase.com/) - Crawlbase: Unleash the power of intelligent web crawling. Seamlessly extract, analyze, and organize data for informed decision-making. Your gateway to efficient and precise web scraping. Enjoy you frist 1000 free requests
 - [Financial Data](https://financialdata.net/) - Get and analyze stock market and financial data (API, Data Viewer, Excel Export).
+- [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, free.
 
 ## Feature Flags
 -  [launchdarkly](https://launchdarkly.com/) - One platform for developers to ship with confidence—combining feature flags, observability, experimentation, analytics, and AI engineering to de-risk every release and reduce outages.


### PR DESCRIPTION
## Add GEO/AEO Tracker to Data Analysis

[GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) is an open-source, local-first AI visibility dashboard. It tracks brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. Free to use (BYOK, self-hosted), with visibility scoring, citation analysis, and competitor battlecards. Perfect addition to the Data Analysis section.