### PR TITLE
Add Scheduling section with free group scheduling tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ an awesome list of free SaaS (software as a service) for you.
   - [Integration Payment](#Integration-Payment)
   - [Corporate Training](#corporate-training)
   - [Automation](#automation)
+  - [Scheduling](#scheduling)
   - [License](#license)
   
 ## AI
@@ -255,6 +256,10 @@ an awesome list of free SaaS (software as a service) for you.
 ## Automation
 - [automate](https://automate.io/) Connect your cloud apps. Automate work.
 
+## Scheduling
+- [AreYouFree](https://areyoufree.uk/) - Free group scheduling polls and booking pages, no sign-up required
+- [When2meet](https://www.when2meet.com/) - Free drag-to-select availability grid for finding group meeting times
+- [Rallly](https://rallly.co/) - Open-source scheduling tool for finding the best date for group meetings
 
 # License
 


### PR DESCRIPTION
Add AreYouFree, When2meet, and Rallly as free scheduling SaaS options.