### PR TITLE
Add GEOScore - free AI search visibility scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ an awesome list of free SaaS (software as a service) for you.
 
 - [Magnetic Engine](https://e.kuaishou.com/) - Kuaishou marketing platform, making brands more attractive
 - [Weimob](http://www.weimob.com/) - Smart business service provider
+- [GEOScore](https://geoscoreai.com/) - Free AI search visibility scanner checking 11 GEO signals including robots.txt, llms.txt, structured data, and citation readiness. Includes free AI Robots.txt Generator and AI Crawler Access Checker.
 
 ## Cost Control Reimbursement
 


### PR DESCRIPTION
Added [GEOScore](https://geoscoreai.com/) to the **Marketing** section.

GEOScore is a free AI search visibility scanner that checks 11 GEO signals including robots.txt, llms.txt, structured data, and citation readiness.

Free tools included:
- AI Robots.txt Generator
- AI Crawler Access Checker

It helps website owners optimize their visibility in AI-powered search engines like ChatGPT, Perplexity, and Gemini.