### PR TITLE
Add Puppyone to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [Open Deep Research](https://github.com/PuppyAgent/OpenDeepResearch) - Open Source Deep Research & Wide Research
 - [VisaCanvas](https://visacanvas.com/) - Free AI-powered EB1A/NIW immigration eligibility assessment with 10-criteria analysis
 - [Notah.ai](https://notah.ai) - AI-powered meeting notes, transcription, and action items, an AI Executive Assistant.
+- [Puppyone](https://www.puppyone.ai) - Free cloud file system built for AI agents. Native MCP, file-level security, version history, 15+ OAuth connectors (Notion/GitHub/Drive/Linear). No credit card required. Open source (Apache 2.0) with Docker self-host option.
 
 
 ## Prompt 


### PR DESCRIPTION
## What this adds

Adds [Puppyone](https://www.puppyone.ai) to the **AI** section.

## Why it fits

Puppyone offers a free hosted tier at [puppyone.ai](https://www.puppyone.ai) — sign up with email, no credit card, no subscription. It's a cloud file system designed for AI agents:

- **Free tier**: full feature access on the hosted version
- **Open source**: Apache 2.0 licensed, full source on [GitHub](https://github.com/puppyone-ai/puppyone)
- **Self-host option**: `docker compose up -d` if you outgrow the free tier
- **15+ OAuth connectors**: Notion, GitHub, Drive, Linear, Gmail — sync external data as agent-readable files
- **Native MCP**: works out-of-box with Claude Code, Cursor, Cline, and any MCP-compatible agent
- **Per-agent ACLs**: file-level security ensures each agent only sees authorized files

Free SaaS for developers building AI agents who need persistent, versioned, ACL-protected storage without standing up infrastructure.

- Site: https://www.puppyone.ai
- Source: https://github.com/puppyone-ai/puppyone
- License: Apache 2.0

Made with [Cursor](https://cursor.com)