### PR TITLE
Add TinyTools to Developer Service section

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [PageShot](https://pageshot.site) - Free screenshot and webpage capture API powered by Playwright
 - [PDFSpark](https://pdfspark.dev) - Free HTML/URL to PDF conversion API built with Playwright
 - [QRMint](https://qrmint.dev) - Free styled QR code generator and API with customizable colors and logos
+- [TinyTools](https://tinytools-smoky.vercel.app/) - Free single-purpose web utilities for developers. Includes SEO meta tag generator, OG image generator, favicon generator, color palette generator, AI cost calculator, AI robots.txt generator, and more. Browser-based, no signup, open source.
 
 ## Form
 


### PR DESCRIPTION
Hi! Adding [TinyTools](https://tinytools-smoky.vercel.app/) to the Developer Service section. It's an open-source collection of free, single-purpose web utilities — SEO meta tag generator, OG image generator, favicon generator, color palette generator, AI cost calculator, AI robots.txt generator, and more. All tools run in the browser with no signup or rate limits. Fits well alongside the existing Developer Service entries (FreeKit, OGForge, QRMint, etc.). Thanks for maintaining this list!