### PR TITLE
Add AI Invoice Maker (free invoice generator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ an awesome list of free SaaS (software as a service) for you.
 - [Ekuaibao](https://www.ekuaibao.com/) - Agile enterprise reimbursement cost control and aggregate consumption platform
 - [Fenbeitong](https://www.fenbeitong.com/) - Enterprise Payment - Reimbursement Management Software - Travel Expense Reimbursement System
 - [InvoiceFlow](https://www.invoiceflow.cc/) - Simple invoicing and billing SaaS with a free forever plan (no credit card), suitable for freelancers and small teams.
-- 
+- [AI Invoice Maker](https://ainvoicemaker.com/) - Free invoice generator with AI-powered payment reminders. 50+ currencies, no signup, no watermark, no credit card. Also supports receipts, quotes, contracts, NDAs, and superbills.
+
 ## Low & No Code Platform
 
 - [Airtable](https://airtable.com/) - Low-code platform for building collaborative apps. Customize your workflow, collaborate, and achieve ambitious outcomes.


### PR DESCRIPTION
Adds [AI Invoice Maker](https://ainvoicemaker.com/) under **Cost Control Reimbursement** alongside InvoiceFlow.

### Why it fits
- Same niche as the existing InvoiceFlow entry (free invoicing SaaS for freelancers/small teams)
- Free forever, no credit card, no signup, no watermark — exact "free SaaS" positioning
- Differentiated by AI-powered payment reminders + multi-document support (receipts, quotes, contracts, NDAs, superbills)

### Entry
- [AI Invoice Maker](https://ainvoicemaker.com/) - Free invoice generator with AI-powered payment reminders. 50+ currencies, no signup, no watermark, no credit card. Also supports receipts, quotes, contracts, NDAs, and superbills.

Happy to revise wording or move section if a different placement fits better.