### PR TITLE
Add TinyTools to Developer Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [PageShot](https://pageshot.site) - Free screenshot and webpage capture API powered by Playwright
 - [PDFSpark](https://pdfspark.dev) - Free HTML/URL to PDF conversion API built with Playwright
 - [QRMint](https://qrmint.dev) - Free styled QR code generator and API with customizable colors and logos
+- [TinyTools](https://tinytools-smoky.vercel.app/) - Free single-purpose web utilities, all browser-based, no signup. Includes domain name generator, OG image generator, AI background remover (runs locally), favicon generator, color palette generator, SEO meta tag generator, AI cost calculator, AI content disclosure generator (EU AI Act compliant), and AI robots.txt generator. Open source.
 
 ## Form
 


### PR DESCRIPTION
Adding [TinyTools](https://tinytools-smoky.vercel.app/) — a free collection of single-purpose, browser-based web utilities (no signup, no tracking). All tools run client-side. Includes domain name generator, OG image generator, AI background remover (runs locally in browser), favicon generator, color palette generator, SEO meta tag generator, AI cost calculator, AI content disclosure generator (EU AI Act compliant), and AI robots.txt generator. Open source.

Placed in **Developer Service** since the section already lists similar free utilities (OGForge, QRMint, PageShot, etc.).

Thanks for maintaining this list!