### PR TITLE
Add Middleware in Log Analysis list

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [Sentry](https://sentry.io/welcome/) - Application monitoring platform helps every developer diagnose, fix, and optimize the performance of their code.
 - [loggly](https://www.loggly.com/) - Log analysis & monitoring in the cloud.
 - [日志易](https://www.rizhiyi.com/) - 自助在线日志分析平台
+- [Middleware](https://middleware.io/) - Monitor logs, metrics and traces with unified log monitoring platform and troubleshoot faster with AI-powered insights.
 
 ## Information
 


### PR DESCRIPTION
Adds Middleware under the Log Analysis section because it's a part of the observability platform. 

It is a valuable addition to the list.