### PR TITLE
Add TinyTools to Developer Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [PageShot](https://pageshot.site) - Free screenshot and webpage capture API powered by Playwright
 - [PDFSpark](https://pdfspark.dev) - Free HTML/URL to PDF conversion API built with Playwright
 - [QRMint](https://qrmint.dev) - Free styled QR code generator and API with customizable colors and logos
+- [TinyTools](https://tinytools-smoky.vercel.app/) - Free single-purpose web utilities, all browser-based, no signup. Includes domain name generator, OG image generator, AI background remover (runs locally in your browser), favicon generator, color palette generator, SEO meta tag generator, AI cost calculator, AI content disclosure generator (EU AI Act), and AI robots.txt generator. Open source.
 
 ## Form
 


### PR DESCRIPTION
Hi! Adding **TinyTools** — a collection of free, browser-based single-purpose web utilities under the Developer Service section.

**What it is:** [TinyTools](https://tinytools-smoky.vercel.app/) is a curated set of 9 free single-purpose tools, all running in the browser with no signup. Notable: the AI background remover runs locally in the browser (no upload to a server), and there's an EU AI Act–compliant content disclosure generator.

**Why it fits the list:** Free SaaS, no login required, easy to use immediately. Several tools (OG image generator, favicon, SEO meta tag generator) are typical needs of small teams launching SaaS products.

Open source. Thanks for maintaining this list!