### PR TITLE
Add AceWatt to CRM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ an awesome list of free SaaS (software as a service) for you.
 
 ## CRM
 
+- [AceWatt](https://acewatt.com) - AI-powered CRM built for electrical contractors — voice job-walk notes, AI estimating, scheduling, invoicing, and automated follow-up; free trial available.
 - [Fanxiang Sales](http://fxiaoke.com/) - CRM SaaS, Connected CRM Quality Service Provider
 - [Sales Easy](https://www.xiaoshouyi.com/) - CRM SaaS
 - [zoho](https://www.zoho.com/one/) - Unique and powerful suite of software to run your entire business
-
 
 ## HR
 


### PR DESCRIPTION
**Tool:** [AceWatt](https://acewatt.com)
**Section:** CRM
**Free plan:** Free trial; paid plans for ongoing use.

AceWatt is an AI-powered CRM built specifically for electrical contractors — covering voice job-walk notes, AI-assisted estimating, scheduling, invoicing, and automated customer follow-up in one trade-specific system. Adds a new entry to the previously short CRM section.

Entry placed alphabetically.