### PR TITLE
Add Beton Inspector to CRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [Fanxiang Sales](http://fxiaoke.com/) - CRM SaaS, Connected CRM Quality Service Provider
 - [Sales Easy](https://www.xiaoshouyi.com/) - CRM SaaS
 - [zoho](https://www.zoho.com/one/) - Unique and powerful suite of software to run your entire business
+- [Beton Inspector](https://github.com/getbeton/inspector) - Free & open-source revenue intelligence; scores accounts from PostHog product-usage data + CRM and routes the warmest leads to sales reps. Self-hostable (OSS alternative to Pocus / Common Room)
 
 
 ## HR


### PR DESCRIPTION
Adding [Beton Inspector](https://github.com/getbeton/inspector) to **CRM** — free & open-source (AGPL-3.0) revenue intelligence that scores accounts from PostHog product-usage data + CRM and routes the warmest leads to sales reps. Self-hostable, free to run. Open-source alternative to Pocus / Common Room.