### PR TITLE
Add IPASIS to Developer Service section

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [PageShot](https://pageshot.site) - Free screenshot and webpage capture API powered by Playwright
 - [PDFSpark](https://pdfspark.dev) - Free HTML/URL to PDF conversion API built with Playwright
 - [QRMint](https://qrmint.dev) - Free styled QR code generator and API with customizable colors and logos
+- [IPASIS](https://ipasis.com) - Free bot detection and fraud prevention API with IP reputation, email validation, and interaction trust scoring. 100 requests/day free tier
 
 ## Form
 


### PR DESCRIPTION
Added [IPASIS](https://ipasis.com) to the Developer Service section.

IPASIS is a free bot detection and fraud prevention API that provides IP reputation scoring, email validation, and interaction trust scoring. The free tier includes 100 requests/day with no credit card required.

Fits the Developer Service category alongside other free developer APIs like LinkMeta, PageShot, and QRMint.