### PR TITLE
Add LinkPost (LinkedIn virality prediction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [VisaCanvas](https://visacanvas.com/) - Free AI-powered EB1A/NIW immigration eligibility assessment with 10-criteria analysis
 - [Notah.ai](https://notah.ai) - AI-powered meeting notes, transcription, and action items, an AI Executive Assistant.
 - [Puppyone](https://www.puppyone.ai) - Free cloud file system built for AI agents. Native MCP, file-level security, version history, 15+ OAuth connectors (Notion/GitHub/Drive/Linear). No credit card required. Open source (Apache 2.0) with Docker self-host option.
+- [LinkPost](https://linkpost.gg) - AI-powered LinkedIn post writer that predicts virality before publishing using 1M+ posts and 300+ factors.
 
 
 ## Prompt 


### PR DESCRIPTION
This PR adds [LinkPost](https://linkpost.gg) to the **AI** section.

## What is LinkPost?

LinkPost is the first scientific approach to LinkedIn content. It analyzes 1M+ posts, scores 300+ measurable factors (22 attention tactics + 11 virality rules + 27 personalized to your writing style), and predicts post virality before publishing (70% precision on sentiment, 90% on debate).

## Why include it here?

- Fits the section: helps creators write higher-performing LinkedIn content
- Active product: V2 publicly launched May 27, 2026
- Public website: https://linkpost.gg
- Trustpilot: 10+ reviews, 100% 5-star
- Used by 100+ paying customers, x1.93 likes on average across active cohort (n=20, 60-day study)

## Disclosure

I'm Yannis Haismann, co-founder of LinkPost. I opened this PR myself rather than asking the community to do it. Happy to adjust formatting, change the wording, or remove it if it's not a good fit. Thanks for maintaining this awesome list!
