### PR TITLE
Add TrustYourWebsite to CMS & Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ an awesome list of free SaaS (software as a service) for you.
 
 - [Webflow](https://webflow.com/) - Empowers designers to build professional, custom websites in a completely visual canvas.
 - [PageGuard](https://pageguard.org) - Free all-in-one website health scanner. Checks SEO, performance (Core Web Vitals), accessibility (WCAG 2.1), and best practices. AI-powered fix suggestions. No signup required.
+- [TrustYourWebsite](https://trustyourwebsite.com) - Automated website compliance scanner for EU and UK small businesses. Checks GDPR, cookie banners, accessibility (WCAG, axe-core), and legal pages. Free scan returns a risk score and issue counts, no signup required.
 
 ## Log Analysis
 


### PR DESCRIPTION
Adds TrustYourWebsite to the **CMS & Website** section.

It's an automated, free-to-use website compliance scanner for EU and UK small businesses — it checks GDPR, cookie banners, accessibility (WCAG, axe-core) and legal pages in one pass. The free scan returns a risk score and issue counts with no signup; a paid report adds full findings and fix instructions. Similar in spirit to PageGuard already listed here, focused on the legal / privacy / accessibility side of website health.

Disclosure: I'm the author of the tool.