### PR TITLE
Add Planning Poker by TeamRetro to Project & Team Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [ones](https://ones.ai/) - R&D management tool integrating agile development and DevOps
 - [tower](https://tower.im/) - Team collaboration tool
 - [Notion](https://www.notion.so/product) - One tool for your whole team. Write, plan, and get organized.
+- [Planning Poker by TeamRetro](https://planning-poker.teamretro.com/) - Free online planning poker for agile teams; private votes, instant reveal, no sign-up.
 
 ## Marketing
 


### PR DESCRIPTION
Adds a free online planning poker tool to the **Project & Team Management** section.

\`\`\`
- [Planning Poker by TeamRetro](https://planning-poker.teamretro.com/) - Free online planning poker for agile teams; private votes, instant reveal, no sign-up.
\`\`\`

Free to use with no sign-up required, matching the spirit of this list.

**Disclosure:** I work at TeamRetro, the maker of this tool.