### PR TITLE
Add Toolsplorer to Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [Meetup](https://www.meetup.com/) - Discover events for all the things you love.
 - [Owler](https://corp.owler.com/) - Hard-to-find company data, and strategic news alerts for savvy executives, marketers and sales professionals.
 - [RemoteClub](https://remoteclub.io/?ref=producthunt) - Find remote jobs for Developers, Designers, Customer Service, Management, Marketing and Sales. Work from anywhere. Hire remote workers!
+- [Toolsplorer](https://toolsplorer.com/) - Free software directory with transparent scoring aggregated from multiple public review sources, price history and side-by-side tool comparisons.
 
 ## Draw
 


### PR DESCRIPTION
Adds [Toolsplorer](https://toolsplorer.com/) under **Information**, alongside the existing directory entries (Owler, RemoteClub).

Toolsplorer is a free-to-use software directory covering 460+ business and productivity tools. What makes it different from the usual listing sites:

- **Transparent scoring** — each score is a weighted average of multiple public review sources (G2, Capterra, Trustpilot, Product Hunt and others), and the per-source breakdown with weights is shown openly on every tool page.
- **Price history** — tracked over time, so you can see which tools raised prices and by how much.
- **Pros and cons from real user discussions**, with the source threads linked for verification.
- Side-by-side comparisons and alternatives for every listed tool.

Free to use, no signup required. Available in English and German.