### PR TITLE
Add Klinky

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [SocialBu](https://socialbu.com/) - AI-powered social media management platform for scheduling, publishing, monitoring, and automating across multiple platforms
 - [Weimob](http://www.weimob.com/) - Smart business service provider
 - [GEOScore](https://geoscoreai.com/) - Free AI search visibility scanner checking 11 GEO signals including robots.txt, llms.txt, structured data, and citation readiness. Includes free AI Robots.txt Generator and AI Crawler Access Checker.
+- [Klinky](https://klinky.io/) - A/B testing link shortener: split one link between two destinations and compare results with real-time click analytics. Free tier available.
 
 ## Cost Control Reimbursement
 


### PR DESCRIPTION
Adds [Klinky](https://klinky.io/) to the Marketing section.

Klinky is an A/B testing link shortener: one short link splits traffic between two destinations at weights you choose, with real-time click analytics to compare variants. It has a free tier, so it fits the list's free-SaaS focus. Entry follows the existing format of the section.
