### PR TITLE
Add Autoposting to Content &amp; Experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [Eqxiu](https://store.eqxiu.com/) - A creative design platform that everyone can use
 - [Draft Design](https://www.gaoding.com/) - Make the design easier
 - [QRCode.Best](https://qrcode.best/) - Create and save dynamic qr codes
+- [Autoposting](https://autoposting.ai) - AI social media manager: generates posts in your own voice, clips long video, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube
 
 
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [Eqxiu](https://store.eqxiu.com/) - A creative design platform that everyone can use
 - [Draft Design](https://www.gaoding.com/) - Make the design easier
 - [QRCode.Best](https://qrcode.best/) - Create and save dynamic qr codes
-- [Autoposting](https://autoposting.ai) - AI social media manager: generates posts in your own voice, clips long video, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube
+- [Autoposting](https://autoposting.ai) - Write, clip and schedule social posts with AI
 
 
 


### PR DESCRIPTION
Adds [Autoposting](https://autoposting.ai) under Content & Experience.

Free tier covers post generation, scheduling and publishing to X, LinkedIn, Instagram, Threads and YouTube, plus video clipping and carousels.

One line added, short-description style matching the section.