### PR TITLE
Add Mydentify llms.txt Generator and Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [PageShot](https://pageshot.site) - Free screenshot and webpage capture API powered by Playwright
 - [PDFSpark](https://pdfspark.dev) - Free HTML/URL to PDF conversion API built with Playwright
 - [QRMint](https://qrmint.dev) - Free styled QR code generator and API with customizable colors and logos
+- [Mydentify llms.txt Generator and Validator](https://mydentify.com/tools/llms-txt-generator-validator) - Free browser-based generator and validator for the proposed llms.txt format, with no signup required
 
 ## Form
 


### PR DESCRIPTION
## Summary

Adds the free, no-signup Mydentify llms.txt Generator and Validator to Developer Service.

The tool creates a proposed llms.txt file or validates pasted content for baseline structure, including one H1, a summary, sections, and absolute links. It does not claim that llms.txt guarantees crawling, citations, or rankings.

## Disclosure

I maintain Mydentify and am submitting this tool directly. The contribution links to the exact free tool page.