### PR TITLE
Add ZeroSMTP to Developer Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ an awesome list of free SaaS (software as a service) for you.
 - [PageShot](https://pageshot.site) - Free screenshot and webpage capture API powered by Playwright
 - [PDFSpark](https://pdfspark.dev) - Free HTML/URL to PDF conversion API built with Playwright
 - [QRMint](https://qrmint.dev) - Free styled QR code generator and API with customizable colors and logos
+- [ZeroSMTP](https://msgwing.com) - Free SMTP relay that still accepts plain username/password auth, for printers and legacy apps that cannot do OAuth; 200 emails/day, sends from a shared domain
 
 ## Form
 


### PR DESCRIPTION
Adds ZeroSMTP under Developer Service — a free SMTP relay that still accepts plain username-and-password authentication, for printers, scanners, NAS units and legacy applications that cannot do OAuth 2.0. Relevant now because Microsoft 365 disables Basic authentication for SMTP AUTH by default at the end of December 2026, and several hardware vendors have published lists of models that will never get firmware for it.

Free with no paid tier. Limits are stated in the entry rather than left to discover: 200 emails/day, and mail is sent from a shared domain rather than the user's own.

https://github.com/msgwing/ZeroSMTP